### PR TITLE
fix prefix duplication on clear()

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -129,6 +129,7 @@ final class Redis implements CacheInterface
     public function clear()
     {
         return $this->client->keys($this->prefix . '*')->then(function (array $keys) {
+            $keys = preg_replace('|^' . preg_quote($this->prefix) . '|', '', $keys);
             return $this->deleteMultiple($keys);
         });
     }


### PR DESCRIPTION
```php
$cache = new Cache($redis, 'focus:');
$cache->set('foo', 'bar');
$cache->clear()
```
would call
```php
$redis->del('focus:focus:foo')
```
because `clear()` finds all the keys matching the prefix and passes those to `deleteMultiple()`, but then `deleteMultiple()` adds the prefix again before deleting.